### PR TITLE
Addition of header slot to autocomplete dropdown

### DIFF
--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -27,6 +27,10 @@
                 v-show="isActive && (data.length > 0 || hasEmptySlot)"
                 ref="dropdown">
                 <div class="dropdown-content">
+                    <div
+                        class="dropdown-item">
+                        <slot name="header"/>
+                    </div>
                     <a
                         v-for="(option, index) in data"
                         :key="index"


### PR DESCRIPTION
Hi

This is a pull request for an extra slot in the autocomplete dropdown component.

There already is a slot named 'empty', for the case where none of the options satisfy the users input. This is a disabled option, sits at the bottom of the dropdown, and only appears when there are no options matching the users input.

```html
<div
             v-if="data.length === 0"
             class="dropdown-item is-disabled">
             <slot name="empty"/>
</div>
```

I am proposing something similar, another slot called 'header', that sits at the top of the dropdown, like so:

```html
<div class="dropdown-content">
         <div
                class="dropdown-item">
                <slot name="header"/>
        </div>
```

**Use case**

1. A user begins to type into the autocomplete, no results are found and therefore they wish to add their typed text as a new entry to the list. The header slot provides a injection point for an 'add new' button or link.

2. A user clicks the autocomplete, open-on-focus prop is set to true, therefore the dropdown opens with options. The user concludes that the option they need is not available and they want to add it. Once again the header slot provides a injection point for an 'add new' button or link.

**Other options considered**

I thought about repurposing the 'empty' slot for this. However, this doesn't work well for two reasons:

1. The option is set to disabled. And therefore the cursor changes to a no entry symbol when you hover over anything within this slot. Which isn't great UX if you want to put a link in there.

2. The slot only appears once the users input has been deemed to not match any available options. However, as in use case (2) the user may realise earlier than this that they want to 'add new' and are therefore looking for an 'add new' link before the empty slot is presented.

**Behaviour Example**

<a href="https://imgur.com/fQAxIFP"><img src="https://i.imgur.com/fQAxIFP.gif" title="source: imgur.com" /></a>

**Testing**

I have tested the proposed slot addition in Chrome and Safari, both desktop and mobile with no issues.

Google Chrome Version 65.0.3325.181 (Official Build) (64-bit)
Safari Version 11.0.3 (13604.5.6)

Thanks! 

Luke

